### PR TITLE
Update to 1.21

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -11,7 +11,7 @@ java {
 }
 
 group = "net.thenextlvl.holograms"
-version = "2.1.2"
+version = "2.1.3"
 
 repositories {
     mavenCentral()
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compileOnly("org.projectlombok:lombok:1.18.32")
-    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
 
     compileOnly("net.thenextlvl.core:annotations:2.0.1")
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.20.6-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")
 
     compileOnly("org.projectlombok:lombok:1.18.32")
     compileOnly("net.thenextlvl.core:annotations:2.0.1")
@@ -39,7 +39,7 @@ dependencies {
 paper {
     name = "HologramAPI"
     main = "net.thenextlvl.hologram.HologramAPI"
-    apiVersion = "1.20"
+    apiVersion = "1.21"
     prefix = "Holograms"
     load = BukkitPluginDescription.PluginLoadOrder.STARTUP
     website = "https://thenextlvl.net"

--- a/plugin/src/main/java/net/thenextlvl/hologram/implementation/CraftHologramLoader.java
+++ b/plugin/src/main/java/net/thenextlvl/hologram/implementation/CraftHologramLoader.java
@@ -76,15 +76,15 @@ public class CraftHologramLoader implements HologramLoader {
             return new ClientboundAddEntityPacket(
                     display.getEntityId(),
                     display.getUniqueId(),
-                    display.getLocation().getX(),
-                    display.getLocation().getY(),
-                    display.getLocation().getZ(),
-                    display.getLocation().getPitch(),
-                    display.getLocation().getYaw(),
+                    display.getX(),
+                    display.getY(),
+                    display.getZ(),
+                    display.getPitch(),
+                    display.getYaw(),
                     display.getHandle().getType(),
                     0,
                     new Vec3(0, 0, 0),
-                    display.getLocation().getYaw()
+                    display.getYaw()
             );
         }
 

--- a/plugin/src/main/java/net/thenextlvl/hologram/implementation/CraftHologramLoader.java
+++ b/plugin/src/main/java/net/thenextlvl/hologram/implementation/CraftHologramLoader.java
@@ -2,10 +2,13 @@ package net.thenextlvl.hologram.implementation;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
 import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.phys.Vec3;
 import net.thenextlvl.hologram.api.HologramLoader;
 import net.thenextlvl.hologram.api.hologram.Hologram;
 import org.bukkit.Location;
@@ -64,9 +67,25 @@ public class CraftHologramLoader implements HologramLoader {
 
         private void load(Hologram hologram, CraftPlayer player) {
             addHologram(player, hologram);
-            var display = ((CraftDisplay) hologram).getHandle();
-            player.getHandle().connection.send(display.getAddEntityPacket());
+            CraftDisplay display = (CraftDisplay) hologram;
+            player.getHandle().connection.send(createAddEntityPacket(display));
             update(hologram, player);
+        }
+
+        private Packet<?> createAddEntityPacket(CraftDisplay display) {
+            return new ClientboundAddEntityPacket(
+                    display.getEntityId(),
+                    display.getUniqueId(),
+                    display.getLocation().getX(),
+                    display.getLocation().getY(),
+                    display.getLocation().getZ(),
+                    display.getLocation().getPitch(),
+                    display.getLocation().getYaw(),
+                    display.getHandle().getType(),
+                    0,
+                    new Vec3(0, 0, 0),
+                    display.getLocation().getYaw()
+            );
         }
 
         private void unload(Hologram hologram, CraftPlayer player) {


### PR DESCRIPTION
Entity.getAddEntityPacket() needs a TrackedEntity since 1.21, the easiest way to fix it is to create the packet manualy.